### PR TITLE
Django 1.8 urls style

### DIFF
--- a/yandex_money/urls.py
+++ b/yandex_money/urls.py
@@ -6,7 +6,7 @@ from .views import NoticeFormView
 from .views import CheckOrderFormView
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^check/$', CheckOrderFormView.as_view(), name='yandex_money_check'),
     url(r'^aviso/$', NoticeFormView.as_view(), name='yandex_money_notice'),
-)
+]


### PR DESCRIPTION
Если не сделать такой фикс, django 1.9 показывает warning:

/home/.../.venv/lib/python3.5/site-packages/yandex_money/urls.py:11: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  url(r'^aviso/$', NoticeFormView.as_view(), name='yandex_money_notice'),
